### PR TITLE
Update to just released WhoAmI to fix cross-compiling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,6 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "0.5.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7154f3f4488071a38189dfd63633df444e7be43b731cc12c41505308fc4972f3"
+checksum = "18bb55566f6f3f8440914233cf63df1eb60b801b5007d376cc46212cb8a9287c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Philip Corliss <pcorliss@50projects.com>"]
 edition = "2018"
 
 [dependencies]
-whoami = "=0.5.3"
+whoami = "=0.8.2"


### PR DESCRIPTION
I believe this closes https://github.com/libcala/whoami/issues/12 (from my testing, upgrading from 0.8.1 to 0.8.2 fixes the issue).